### PR TITLE
Fix for build and deploy of 3360

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM mhalagan1nmdp/gfe-base:latest
+FROM mhalagan1nmdp/gfe-base:latest 
 
-COPY bin/* opt/
-COPY requirements.txt opt/
+ADD bin/* /opt/
+ADD requirements.txt /opt
 
 WORKDIR /opt
 
@@ -9,7 +9,7 @@ ENV NEO4J_HOME /var/lib/neo4j
 ENV NEO4J_BIN /var/lib/neo4j/bin
 ENV NEO4J_CONF /opt/conf
 
-ARG IMGT="3170,3190,3200,3210,3240,3250,3310"
+ARG IMGT="3360"
 ARG K=False
 ARG AN=False
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -26,5 +26,8 @@ if [ "$ALIGN" == "True" ]; then
 	sh ${BIN}/get_alignments.sh
 fi
 
-python3 ${BIN}/build_gfedb.py -o $1 -r ${RELEASES} ${KIRFLAG} ${ALIGNFLAG} -v
+#remove the offending lines of C that don't conform or are missing some information
+sed -i.bak /C*05:208N/d /data/3360/C_gen.sth
+sed -i.bak /C*05:206/d /data/3360/C_gen.sth
 
+python3 ${BIN}/build_gfedb.py -o $1 -r ${RELEASES} ${KIRFLAG} ${ALIGNFLAG} -v

--- a/bin/build_gfedb.py
+++ b/bin/build_gfedb.py
@@ -4,6 +4,11 @@
 # TODO: **** ADD HAS_FEATURE
 #       between SEQUENCE and features
 import pandas as pd
+try:
+    from typing import GenericMeta  # python 3.6
+except ImportError:
+    # in 3.7, genericmeta doesn't exist but we don't need it
+    class GenericMeta(type): pass
 from seqann.models.annotation import Annotation
 from Bio.SeqFeature import SeqFeature
 from pygfe.pygfe import pyGFE
@@ -45,7 +50,7 @@ skip_alleles = ["HLA-DRB5*01:11", "HLA-DRB5*01:12", "HLA-DRB5*01:13",
                 "HLA-DRB5*02:03", "HLA-DRB5*02:04", "HLA-DRB5*02:05",
                 "HLA-DRB5*01:01:02", "HLA-DRB5*01:03", "HLA-DRB5*01:05",
                 "HLA-DRB5*01:06", "HLA-DRB5*01:07", "HLA-DRB5*01:09",
-                "HLA-DRB5*01:10N"]
+                "HLA-DRB5*01:10N", "HLA-C*05:208N", "HLA-C*05:206"]
 
 hla_loci = ['HLA-A', 'HLA-B', 'HLA-C', 'HLA-DRB1', 'HLA-DQB1',
             'HLA-DPB1', 'HLA-DQA1', 'HLA-DPA1', 'HLA-DRB3',
@@ -90,7 +95,9 @@ def hla_alignments(dbversion):
         sth_prot = data_dir + "/../data/" + dbversion + "/" + loc.split("-")[1] + "_prot.sth"
 
         logging.info("Loading " + sth_gen)
-        align_gen = AlignIO.read(open(sth_gen), "stockholm")
+        print(skip_alleles)
+        #align_gen = AlignIO.read(open(sth_gen), "stockholm")
+        align_gen = next(AlignIO.parse(sth_gen, "stockholm"))
         gen_seq = {"HLA-" + a.name: str(a.seq) for a in align_gen}
         logging.info("Loaded " + str(len(gen_seq)) + " genomic " + loc + " sequences")
         gen_aln.update({loc: gen_seq})
@@ -102,8 +109,8 @@ def hla_alignments(dbversion):
         nuc_aln.update({loc: nuc_seq})
 
         # https://github.com/ANHIG/IMGTHLA/issues/158 
-        if str(dbversion) == ["3320", "3360"]:
-            continue
+        #if str(dbversion) == ["3320", "3360"]:
+        #    continue
 
         logging.info("Loading " + sth_prot)
         align_prot = AlignIO.read(open(sth_prot), "stockholm")
@@ -625,6 +632,7 @@ def main():
             if hasattr(allele, 'seq'):
                 hla_name = allele.description.split(",")[0]
                 loc = allele.description.split(",")[0].split("*")[0]
+                print (hla_name, skip_alleles, loc)
                 if hla_name in skip_alleles:
                     logging.info("SKIPPING = " + allele.description.split(",")[0] + " " + dbversion)
                     continue

--- a/bin/build_gfedb.py
+++ b/bin/build_gfedb.py
@@ -102,7 +102,7 @@ def hla_alignments(dbversion):
         nuc_aln.update({loc: nuc_seq})
 
         # https://github.com/ANHIG/IMGTHLA/issues/158 
-        if str(dbversion) == "3320":
+        if str(dbversion) == ["3320", "3360"]:
             continue
 
         logging.info("Loading " + sth_prot)

--- a/bin/get_alignments.sh
+++ b/bin/get_alignments.sh
@@ -7,7 +7,8 @@ DATA_DIR=${BIN}/../data
 mkdir -p ${DATA_DIR}
 
 loci="A B C DRB1 DQB1 DPB1 DPA1 DQA1"
-base_url="https://media.githubusercontent.com/media/ANHIG/IMGTHLA"
+#base_url="https://media.githubusercontent.com/media/ANHIG/IMGTHLA"
+base_url="https://raw.githubusercontent.com/ANHIG/IMGTHLA"
 
 RELEASES=`echo ${RELEASES} | sed s'/"//'g | sed s'/,/ /g'`
 

--- a/bin/get_alignments.sh
+++ b/bin/get_alignments.sh
@@ -38,7 +38,6 @@ for dbversion in ${RELEASES};do
 	done
 done
 
-
 if [ "$KIR" == "True" ]; then
 	kirloci="'KIR3DS1 KIR3DP1 KIR3DL3 KIR3DL2 KIR3DL1 KIR2DS5 KIR2DS4 KIR2DS3 KIR2DS2 KIR2DS1 KIR2DP1 KIR2DL4"
 	kirbase="ftp://ftp.ebi.ac.uk/pub/databases/ipd/kir/msf"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ certifi==2017.11.5
 gitdb2==2.0.3
 html5lib==1.0.1
 lxml==4.1.1
-#initial version that was needed:numpy==1.16.4 moved to latest
-numpy
+numpy==1.13.3
 pandas==0.21.1
 pyard==0.0.1
 pygfe==0.0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ certifi==2017.11.5
 gitdb2==2.0.3
 html5lib==1.0.1
 lxml==4.1.1
-numpy==1.13.3
+#initial version that was needed:numpy==1.16.4 moved to latest
+numpy
 pandas==0.21.1
 pyard==0.0.1
 pygfe==0.0.13


### PR DESCRIPTION
Modified just enough to get this working.    3360 has two IDs that appear to be missing a ".". These two
IDs are removed from the file before processing.

The two sequences are:
C*05:208N
C*05:206

Current use of the mhalagannmdp docker image is intentional.  

ToDo: I noticed that the pygfe and pyGFE also might need to be updated.    The Docker build  process will need to be unpacked so that he dockerfile is the recipie for the build for that entire image from an already supported public Biopython image.

The current method is not very transparent and we are relying on the image that was created previously.  This will not always work and will also have eventual vulnerabilities.

