### PR TITLE
Fix incorrect comparison operator causing 3350 to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Graph database representing IPD-IMGT/HLA sequence data as GFE.
     - [Creating a Python Virtual Environment](#creating-a-python-virtual-environment)
   - [Troubleshooting](#troubleshooting)
   - [Authors](#authors)
-  - [References & Links](#references--links)
+  - [References \& Links](#references--links)
 
 ## Project Structure
 ```bash
@@ -533,6 +533,7 @@ jupyter kernelspec uninstall gfe-db
  * [feature.nmdp-bioinformatics.org](https://feature.nmdp-bioinformatics.org)
  * [gfe.b12x.org](http://gfe.b12x.org)
  * [Neo4j Cloud Virtual Machines](https://neo4j.com/developer/neo4j-cloud-vms/)
+ * [Getting Certificates for Neo4j with LetsEncrypt](https://medium.com/neo4j/getting-certificates-for-neo4j-with-letsencrypt-a8d05c415bbd)
 
 -----------------
 <br>

--- a/gfe-db/pipeline/jobs/Makefile
+++ b/gfe-db/pipeline/jobs/Makefile
@@ -9,14 +9,6 @@ deploy:
 	# $(MAKE) ecr.login
 	$(MAKE) deploy.ecr.jobs.build
 
-# Skipped, causes timeout issues on some internet connections; added to individual build targets
-# ecr.login:
-# 	@echo "$$(gdate -u +'%Y-%m-%d %H:%M:%S.%3N') - Logging into ECR" 2>&1 | tee -a $$CFN_LOG_PATH
-# 	@aws ecr get-login-password \
-# 		--region "$${AWS_REGION}" | docker login \
-# 			--username AWS \
-# 			--password-stdin "$${ECR_BASE_URI}" 2>&1 | tee -a $$CFN_LOG_PATH || true
-
 # TODO: use a for loop for build/load targets
 deploy.ecr.jobs.build:
 	@echo "$$(gdate -u +'%Y-%m-%d %H:%M:%S.%3N') - Pushing Build Service Docker image to ECR" 2>&1 | tee -a $$CFN_LOG_PATH
@@ -24,7 +16,10 @@ deploy.ecr.jobs.build:
 		--region "$${AWS_REGION}" | docker login \
 			--username AWS \
 			--password-stdin "$${ECR_BASE_URI}" 2>&1 | tee -a $$CFN_LOG_PATH || true && \
-	docker build -t "$${BUILD_REPOSITORY}" build/ && \
+	docker build \
+		-t "$${BUILD_REPOSITORY}" \
+		--platform "linux/amd64" \
+		build/ && \
 	docker tag "$${BUILD_REPOSITORY}:latest" "$${ECR_BASE_URI}/$${BUILD_REPOSITORY}:latest" && \
 	docker push "$${ECR_BASE_URI}/$${BUILD_REPOSITORY}:latest" 2>&1 | tee -a $$CFN_LOG_PATH || true
 

--- a/gfe-db/pipeline/jobs/build/run.sh
+++ b/gfe-db/pipeline/jobs/build/run.sh
@@ -2,7 +2,7 @@
 
 START_EXECUTION=$SECONDS
 
-export ROOT=$(dirname $(dirname "$0"))
+export ROOT="$(dirname "$(dirname "$0")")"
 export BIN_DIR=$ROOT/scripts
 export SRC_DIR=$ROOT/src
 export DATA_DIR=$ROOT/../data
@@ -47,7 +47,7 @@ fi
 # Check if data directory exists
 if [ ! -d "$DATA_DIR" ]; then
 	echo "Creating new directory in root: $DATA_DIR"
-	mkdir -p $DATA_DIR
+	mkdir -p "$DATA_DIR"
 else
 	# TODO: get full path
 	echo "Data directory: $DATA_DIR"
@@ -57,7 +57,7 @@ fi
 if [ ! -d "$LOGS_DIR" ]; then
 	# TODO: get full path
 	echo "Creating logs directory: $LOGS_DIR"
-	mkdir -p $LOGS_DIR
+	mkdir -p "$LOGS_DIR"
 else
 	# TODO: get full path
 	echo "Logs directory: $LOGS_DIR"
@@ -67,8 +67,8 @@ fi
 if [ "$MEM_PROFILE" == "True" ]; then
 	echo "Memory profiling is set to $MEM_PROFILE."
 	MEM_PROFILE_FLAG="-p"
-	touch $LOGS_DIR/mem_profile_agg.txt
-	touch $LOGS_DIR/mem_profile_diff.txt
+	touch "$LOGS_DIR/mem_profile_agg.txt"
+	touch "$LOGS_DIR/mem_profile_diff.txt"
 else
 	MEM_PROFILE_FLAG=""
 fi
@@ -85,13 +85,13 @@ fi
 if [ "$ALIGN" == "True" ]; then
 	echo "Loading alignments..."
 	ALIGNFLAG="-a"
-	sh $BIN_DIR/get_alignments.sh
+	sh "$BIN_DIR/get_alignments.sh"
 else
 	ALIGNFLAG=""
 fi
 
 # Build csv files
-RELEASES=`echo "${RELEASES}" | sed s'/"//'g | sed s'/,/ /g'`
+RELEASES=$(echo "${RELEASES}" | sed s'/"//'g | sed s'/,/ /g')
 
 for release in ${RELEASES}; do
 
@@ -102,27 +102,27 @@ for release in ${RELEASES}; do
 	if [ ! -d "$DATA_DIR/$release/csv" ]; then
 		# TODO: get full path
 		echo "Creating new directory in root: $DATA_DIR/$release/csv..."
-		mkdir -p $DATA_DIR/$release/csv
+		mkdir -p "$DATA_DIR/$release/csv"
 	else
 		# TODO: get full path
 		echo "CSV directory: $DATA_DIR/$release/csv"
 	fi
 
 	# Check if DAT file exists
-	if [ -f $DATA_DIR/$release/hla.$release.dat ]; then
+	if [ -f "$DATA_DIR/$release/hla.$release.dat" ]; then
 		echo "DAT file for release $release already exists"
 	else
 		echo "Downloading DAT file for release $release..."
-		if [ "$(echo "$release" | bc -l)" -le 3350  ]; then
+		if [ "$(echo "$release" | bc -l)" -lt 3350  ]; then
 
 			# Should be environment variable
 			imgt_hla_raw_url='https://raw.githubusercontent.com/ANHIG/IMGTHLA'
 			echo "Downloading $imgt_hla_raw_url/$release/hla.dat to $DATA_DIR/$release/hla.$release.dat"
-			curl -SL $imgt_hla_raw_url/$release/hla.dat > $DATA_DIR/$release/hla.$release.dat
+			curl -SL "$imgt_hla_raw_url/$release/hla.dat" > "$DATA_DIR/$release/hla.$release.dat"
 		else
 			imgt_hla_media_url='https://media.githubusercontent.com/media/ANHIG/IMGTHLA'
 			echo "Downloading $imgt_hla_media_url/$release/hla.dat to $DATA_DIR/$release/hla.$release.dat"
-			curl -SL $imgt_hla_media_url/$release/hla.dat > $DATA_DIR/$release/hla.$release.dat
+			curl -SL "$imgt_hla_media_url/$release/hla.dat" > "$DATA_DIR/$release/hla.$release.dat"
 		fi
 	fi
 	
@@ -134,22 +134,22 @@ for release in ${RELEASES}; do
 		$ALIGNFLAG \
 		$MEM_PROFILE_FLAG \
 		-v \
-		-l $LIMIT
+		-l "$LIMIT"
 	[ $? -ne 0 ] && exit 1;
 
 	# TODO: Use this S3 hierarchy: root/release/csv | logs
 	echo -e "Uploading CSVs to s3://$GFE_BUCKET/data/$release/csv/:\n$(ls $DATA_DIR/$release/csv/)"
-	aws s3 --recursive cp $DATA_DIR/$release/csv/ s3://$GFE_BUCKET/data/$release/csv/ > $LOGS_DIR/s3Copy$$LOG_FILE
-	mv $LOGS_DIR/gfeBuildLogs.txt $LOGS_DIR/gfeBuildLogs.$release.txt
-	mv $LOGS_DIR/s3Copy$$LOG_FILE $LOGS_DIR/s3CopyLog.$release.txt
+	aws s3 --recursive cp "$DATA_DIR/$release/csv/" s3://$GFE_BUCKET/data/$release/csv/ > "$LOGS_DIR/s3Copy$$LOG_FILE"
+	mv "$LOGS_DIR/gfeBuildLogs.txt" "$LOGS_DIR/gfeBuildLogs.$release.txt"
+	mv "$LOGS_DIR/s3Copy$$LOG_FILE" "$LOGS_DIR/s3CopyLog.$release.txt"
 
 	if [ "$MEM_PROFILE" == "True" ]; then
-		mv $LOGS_DIR/mem_profile_agg.txt $LOGS_DIR/mem_profile_agg.$release.txt
-		mv $LOGS_DIR/mem_profile_diff.txt $LOGS_DIR/mem_profile_diff.$release.txt
+		mv "$LOGS_DIR/mem_profile_agg.txt" "$LOGS_DIR/mem_profile_agg.$release.txt"
+		mv "$LOGS_DIR/mem_profile_diff.txt" "$LOGS_DIR/mem_profile_diff.$release.txt"
 	fi
 
 	echo -e "Uploading logs to s3://$GFE_BUCKET/logs/$release/:\n$(ls $LOGS_DIR/)"
-	aws s3 --recursive cp $LOGS_DIR/ s3://$GFE_BUCKET/logs/pipeline/build/$release/ > $LOGS_DIR/s3CopyLog.Local.txt
+	aws s3 --recursive cp "$LOGS_DIR/" s3://$GFE_BUCKET/logs/pipeline/build/$release/ > "$LOGS_DIR/s3CopyLog.Local.txt"
 
 done
 

--- a/gfe-db/pipeline/jobs/build/src/app.py
+++ b/gfe-db/pipeline/jobs/build/src/app.py
@@ -506,7 +506,8 @@ if __name__ == '__main__':
                         help="Option for running in verbose",
                         action="store_true")
 
-    # TO DO: add option to specify last n releases
+    # TO DO: add option to specify last n releases UPDATE: instead of having this script handle multiple releases,
+    # have it handle one release and just call it multiple times for an array or queue of releases
     # parser.add_argument("-n", "--number",
     #                     required=False,
     #                     help="Number of IMGT/DB releases",
@@ -637,6 +638,6 @@ if __name__ == '__main__':
                 logger.error("Failed to send message")
                 raise err
 
-    logging.info(f'Finished build for version ${imgt_release}')
+    logging.info(f'Finished build for version {imgt_release}')
     end = time.time()
     logging.info(f'****** Build finished in {round(end - start, 2)} seconds ******')


### PR DESCRIPTION
## Description
The build script was using `≤` when it should have been using `<`:
```bash
echo "Downloading DAT file for release $release..."
if [ "$(echo "$release" | bc -l)" -le 3350  ]; then
```

This was causing the script to access the wrong download URL for the DAT for that version resulting in no data.

Fix:
```bash
echo "Downloading DAT file for release $release..."
if [ "$(echo "$release" | bc -l)" -lt 3350  ]; then
```

## Notes
In addition to the error fix, the deployment platform is specified when building the Docker image to avoid issues when working on M1/M2 Macs:
```bash
	docker build \
		-t "$${BUILD_REPOSITORY}" \
		--platform "linux/amd64" \ # M1/M2 Macs use "linux/arm64" but AWS Batch is not currently
		build/ && \
```