### PR TITLE
Fix failure when `limit=''`

### DIFF
--- a/gfe-db/pipeline/jobs/build/src/app.py
+++ b/gfe-db/pipeline/jobs/build/src/app.py
@@ -526,7 +526,6 @@ if __name__ == '__main__':
                         help="Limit number of records in output",
                         default=None,
                         nargs='?',
-                        type=int,
                         action="store")
 
     args = parser.parse_args()
@@ -550,7 +549,7 @@ if __name__ == '__main__':
     _mem_profile = True if '-p' in sys.argv else False
     verbose = True if '-v' in sys.argv else False
     verbosity = 1 #args.verbosity if args.verbosity else None
-    limit = args.limit if args.limit else None #min(args.count, args.limit)
+    limit = int(args.limit) if args.limit else None #min(args.count, args.limit)
 
     #data_dir = f'{data_dir}/{dbversion}'
     # data_dir = os.path.dirname(__file__) + f"/../data/{dbversion}"


### PR DESCRIPTION
For input:
```
{
  "ALIGN": "False",
  "KIR": "False",
  "LIMIT": "",
  "MEM_PROFILE": "False",
  "RELEASES": "3350"
}
```

Was failing with:
```
usage: app.py [-h] -o OUT_DIR [-r RELEASE] [-k] [-a] [-p] [-v] [-l [LIMIT]]
app.py: error: argument -l/--limit: invalid int value: ''
```
The calling script now calls with `"$LIMIT"`, so `""` is set for blank limit. Fix was to cast to `int` only when a value exists.