### PR TITLE
Renew database SSL certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ response.json
 neo4j.conf
 ___*
 gfedb.zip
+gfe-db/pipeline/jobs/build/event.json
+gfe-db/pipeline/statemachines/test*
+reports/
+_cache/

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,13 @@ database.reboot:
 database.sync-scripts:
 	$(MAKE) -C ${APP_NAME}/database/ service.config.scripts.sync
 
+# # TODO get expiration date, automate renewal
+# database.ssl.get-expiration:
+# 	$(MAKE) -C ${APP_NAME}/database/ service.ssl.get-expiration
+
+database.ssl.renew-cert:
+	$(MAKE) -C ${APP_NAME}/database/ service.ssl.renew-cert
+
 database.backup:
 	@echo "Backing up $${APP_NAME} server..."
 	$(MAKE) -C ${APP_NAME}/database/ service.backup

--- a/gfe-db/database/Makefile
+++ b/gfe-db/database/Makefile
@@ -52,6 +52,13 @@ service.config.scripts.sync: service.config.scripts.deploy
 		--targets "Key=instanceids,Values=${INSTANCE_ID}" \
 		--comment "${STAGE}=${APP_NAME} backup service" 2>&1 | tee -a $$CFN_LOG_PATH || true
 
+service.ssl.renew-cert:
+	@aws ssm send-command \
+		--document-name "AWS-RunShellScript" \
+		--parameters "commands=[cd /home/bitnami && sudo make ssl.renew-cert]" \
+		--targets "Key=instanceids,Values=${INSTANCE_ID}" \
+		--comment "${STAGE}-${APP_NAME} SSL certificate renewal utility" 2>&1 | tee -a $$CFN_LOG_PATH || true
+
 service.config.cloudwatch-agent.deploy:
 	@mkdir -p amazon-cloudwatch-agent/tmp/ 
 	@cat amazon-cloudwatch-agent/amazon-cloudwatch-agent.json | sed "s/STAGE/$${STAGE}/g" | sed "s/APP_NAME/$${APP_NAME}/g" > amazon-cloudwatch-agent/tmp/_amazon-cloudwatch-agent.json

--- a/gfe-db/database/scripts/Makefile
+++ b/gfe-db/database/scripts/Makefile
@@ -187,6 +187,9 @@ neo4j.create-report:
 ssl.create-cert:
 	@bash init/create_cert.sh "${SUBDOMAIN}.${HOST_DOMAIN}" ${ADMIN_EMAIL}
 
+ssl.renew-cert:
+	@bash init/renew_cert.sh "${SUBDOMAIN}.${HOST_DOMAIN}"
+
 copy-logs:
 	@mkdir -p ${LOGS_DIR}/neo4j ${LOGS_DIR}/system
 	$(MAKE) logs.bootstrap

--- a/gfe-db/database/scripts/init/renew_cert.sh
+++ b/gfe-db/database/scripts/init/renew_cert.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -x
+
+# Part of user data, to be run on the database instance on initialization, or later for renewal
+
+echo "Renewing SSL certificate..."
+export NEO4J_HOME=/opt/bitnami/neo4j
+
+# Passed from command line
+DOMAIN=$1
+# ADMIN_EMAIL=$2
+
+# certbot certonly -n \
+#   -d $DOMAIN \
+#   --standalone \
+#   -m $ADMIN_EMAIL \
+#   --agree-tos \
+#   --redirect
+
+certbot renew
+
+chgrp -R neo4j /etc/letsencrypt/*
+chmod -R g+rx /etc/letsencrypt/*
+mkdir -p $NEO4J_HOME/certificates/{bolt,cluster,https}/trusted
+
+for certsource in bolt cluster https; do
+  ln -sf "/etc/letsencrypt/live/$DOMAIN/fullchain.pem" "$NEO4J_HOME/certificates/$certsource/neo4j.cert"
+  ln -sf "/etc/letsencrypt/live/$DOMAIN/privkey.pem" "$NEO4J_HOME/certificates/$certsource/neo4j.key"
+  ln -sf "/etc/letsencrypt/live/$DOMAIN/fullchain.pem" "$NEO4J_HOME/certificates/$certsource/trusted/neo4j.cert"
+done
+
+chgrp -R neo4j $NEO4J_HOME/certificates/*
+chmod -R g+rx $NEO4J_HOME/certificates/*
+
+exit 0


### PR DESCRIPTION
## Description
Adds logic and basic automation for renewing the SSL certificate on gfe-db.

### Usage
1. Make sure AWS credentials are valid
2. Pull remote changes to local repository `git pull`
3. Sync scripts to the database instance `make database.sync-scripts`
4. Renew the certificate `make database.ssl.renew-cert`

### Validation
* After renewing the certificate, navigate to the AWS Systems Manager console &rarr; Run Command &rarr; Command history and click on the most recent execution for `AWS-RunShellScript`, then click on the Instance ID
* Examine the logs under Output and Error