### PR TITLE
Use SV field instead of AC field for IPD_Accession name property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ ifeq ($(SPLASH_FONT),slant)
 	@echo "\033[0;34m \__, //_/   \___/            \____//_____/ "
 	@echo "\033[0;34m/____/                                      "
 	@echo "\033[0;34m                                            "
-	@echo "\033[0;34mCopyright © 2002-2023 National Marrow Donor Program. All rights reserved."
+	@echo "\033[0;34mCopyright © 2002-2024 National Marrow Donor Program. All rights reserved."
 	@echo "\033[0;34m                                            \033[0m"
 endif
 

--- a/README.md
+++ b/README.md
@@ -650,9 +650,8 @@ set -a; source .env.<stage>; set +a
 ```bash
 # Run from the root directory of gfe-db
 docker run \
-    --restart always \
+    --name gfedb \
     --publish=7474:7474 --publish=7687:7687 \
-    --volume=$(pwd)/gfe-db/local/neo4j/logs:/logs \
     $DOCKER_USERNAME/gfe-db:latest
 ```
 3. Navigate to `http://localhost:7474/browser/` to access the Neo4j browser. There is no authentication set so you can leave the username and password fields blank.

--- a/gfe-db/pipeline/jobs/build/src/app.py
+++ b/gfe-db/pipeline/jobs/build/src/app.py
@@ -229,7 +229,7 @@ def build_GFE(allele):
 
         row = {
             "gfe_name": gfe_name,
-            "acc_name": allele.name,
+            "acc_name": allele.id,
             "locus": locus,
             "hla_name": hla_name,
             #"a_name": hla_name.split("-")[1],


### PR DESCRIPTION
## Description
Update the EMBL dat / Cypher model mapping to use the SV field (`SeqIO.id`) instead of the AC field (`SeqIO.name`) for the `IPD_Accession.name` relationship.